### PR TITLE
Export ratios

### DIFF
--- a/modularscale.js
+++ b/modularscale.js
@@ -1,21 +1,22 @@
-// Values
-var minorSecond   = 16/15;
-var majorSecond   = 1.125;
-var minorThird    = 1.2;
-var majorThird    = 1.25;
-var perfectFourth = 4/3;
-var augFourth     = 1.414;
-var perfectFifth  = 1.5;
-var minorSixth    = 1.6;
-var goldenSection = 1.61803398875;
-var majorSixth    = 5/3;
-var minorSeventh  = 16/9;
-var majorSeventh  = 1.875;
-var octave        = 2;
-var majorTenth    = 2.5;
-var majorEleventh = 8/3;
-var majorTwelfth  = 3;
-var doubleOctave  = 4;
+var ratios = {
+  minorSecond: 16/15,
+  majorSecond: 1.125,
+  minorThird: 1.2,
+  majorThird: 1.25,
+  perfectFourth: 4/3,
+  augFourth: 1.414,
+  perfectFifth: 1.5,
+  minorSixth: 1.6,
+  goldenSection: 1.61803398875,
+  majorSixth: 5/3,
+  minorSeventh: 16/9,
+  majorSeventh: 1.875,
+  octave: 2,
+  majorTenth: 2.5,
+  majorEleventh: 8/3,
+  majorTwelfth: 3,
+  doubleOctave: 4
+};
 
 // Function settings
 var modularscale = {
@@ -74,4 +75,4 @@ function ms(v,settings) {
   return msFunction(v,settings);
 }
 
-module.exports = ms;
+module.exports = { ms, ratios };


### PR DESCRIPTION
- Before this change, ratios couldn't be used by consumers of this module.
- This is a breaking API change that should result in a major version bump.

The motivation for this change is to allow us to do:
`import { ms, ratios } from 'modularscale-js'`

and subsequently do:
`const fontSize = ms(2, { base: 18, ratio: ratios.goldenSection })`

On a side note I thought the number alignment looked odd in the object literal, but I'll happily amend the commit if you want me to reimplement that.

Also, I might have some more suggestions to improving this module if you are open to it :)